### PR TITLE
Created namedtuples to use for job status and backfill windows

### DIFF
--- a/balsam/platform/scheduler/cobalt_sched.py
+++ b/balsam/platform/scheduler/cobalt_sched.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 def parse_cobalt_time_minutes(t_str):
     try:
         H, M, S = map(int, t_str.split(":"))
-    except ValueError:
+    except:
         return 0
     else:
         return H * 60 + M + round(S / 60)
@@ -18,7 +18,7 @@ class CobaltScheduler(SubprocessSchedulerInterface):
     status_exe = "qstat"
     submit_exe = "qsub"
     delete_exe = "qdel"
-    nodelist_exe = "nodelist"
+    backfill_exe = "nodelist"
 
     # maps scheduler states to Balsam states
     job_states = {
@@ -100,7 +100,7 @@ class CobaltScheduler(SubprocessSchedulerInterface):
             "id": lambda id: int(id),
             "state": CobaltScheduler._node_state_map,
             "queues": lambda x: x.split(":"),
-            "backfill_time": lambda x: parse_cobalt_time_minutes(x),
+            "backfill_time_min": lambda x: parse_cobalt_time_minutes(x),
         }
         return nodelist_field_map.get(balsam_field, lambda x: x)
 
@@ -142,7 +142,7 @@ class CobaltScheduler(SubprocessSchedulerInterface):
         return [self.delete_exe, str(job_id)]
 
     def _render_backfill_args(self):
-        return [self.nodelist_exe]
+        return [self.backfill_exe]
 
     def _parse_submit_output(self, submit_output):
         try:
@@ -156,28 +156,30 @@ class CobaltScheduler(SubprocessSchedulerInterface):
         status_dict = {}
         job_lines = raw_output.split("\n")[2:]
         for line in job_lines:
+            if len(line.strip()) == 0: continue
             job_stat = self._parse_status_line(line)
             if job_stat:
-                id = int(job_stat["id"])
+                id = int(job_stat.id)
                 status_dict[id] = job_stat
         return status_dict
 
     def _parse_status_line(self, line):
-        status = JobStatus()
         fields = line.split()
         if len(fields) != len(self.status_fields):
-            return status
+            return JobStatus()
 
+        status = {}
         for name, value in zip(self.status_fields, fields):
             func = self._status_field_map(name)
             status[name] = func(value)
-        return status
+        return JobStatus(**status)
 
     def _parse_backfill_output(self, stdout):
         raw_lines = stdout.split("\n")
         nodelist = []
         node_lines = raw_lines[2:]
         for line in node_lines:
+            if len(line.strip()) == 0: continue
             line_dict = self._parse_nodelist_line(line)
             if line_dict["backfill_time_min"] > 0 and line_dict["state"] == "idle":
                 nodelist.append(line_dict)
@@ -192,7 +194,6 @@ class CobaltScheduler(SubprocessSchedulerInterface):
         fields = line.split()
         if len(fields) != len(self.nodelist_fields):
             return status
-
         for name, value in zip(self.nodelist_fields, fields):
             func = CobaltScheduler._nodelist_field_map(name)
             status[name] = func(value)
@@ -209,9 +210,10 @@ class CobaltScheduler(SubprocessSchedulerInterface):
             for queue in queues:
                 if queue in windows:
                     found_self = False
-                    for window in windows[queue]:
+                    for i,window in enumerate(windows[queue]):
                         if bf_time >= window.backfill_time_min:
-                            window.nodes += 1
+                            windows[queue][i] = BackfillWindow(num_nodes=window.num_nodes+1,
+                                                               backfill_time_min=window.backfill_time_min)
                         if bf_time == window.backfill_time_min:
                             found_self = True
                     if not found_self:

--- a/balsam/platform/scheduler/cobalt_sched.py
+++ b/balsam/platform/scheduler/cobalt_sched.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 def parse_cobalt_time_minutes(t_str):
     try:
         H, M, S = map(int, t_str.split(":"))
-    except:
+    except ValueError:
         return 0
     else:
         return H * 60 + M + round(S / 60)
@@ -156,7 +156,8 @@ class CobaltScheduler(SubprocessSchedulerInterface):
         status_dict = {}
         job_lines = raw_output.split("\n")[2:]
         for line in job_lines:
-            if len(line.strip()) == 0: continue
+            if len(line.strip()) == 0:
+                continue
             job_stat = self._parse_status_line(line)
             if job_stat:
                 id = int(job_stat.id)
@@ -179,7 +180,8 @@ class CobaltScheduler(SubprocessSchedulerInterface):
         nodelist = []
         node_lines = raw_lines[2:]
         for line in node_lines:
-            if len(line.strip()) == 0: continue
+            if len(line.strip()) == 0:
+                continue
             line_dict = self._parse_nodelist_line(line)
             if line_dict["backfill_time_min"] > 0 and line_dict["state"] == "idle":
                 nodelist.append(line_dict)
@@ -210,10 +212,12 @@ class CobaltScheduler(SubprocessSchedulerInterface):
             for queue in queues:
                 if queue in windows:
                     found_self = False
-                    for i,window in enumerate(windows[queue]):
+                    for i, window in enumerate(windows[queue]):
                         if bf_time >= window.backfill_time_min:
-                            windows[queue][i] = BackfillWindow(num_nodes=window.num_nodes+1,
-                                                               backfill_time_min=window.backfill_time_min)
+                            windows[queue][i] = BackfillWindow(
+                                num_nodes=window.num_nodes + 1,
+                                backfill_time_min=window.backfill_time_min,
+                            )
                         if bf_time == window.backfill_time_min:
                             found_self = True
                     if not found_self:

--- a/balsam/platform/scheduler/dummy.py
+++ b/balsam/platform/scheduler/dummy.py
@@ -208,13 +208,13 @@ class DummyScheduler(SubprocessSchedulerInterface):
 
         # build example output dictionary
         windows = {
-            'default_queue': [
-                BackfillWindow(num_nodes=5,backfill_time_min=60),
-                BackfillWindow(num_nodes=15,backfill_time_min=45)
+            "default_queue": [
+                BackfillWindow(num_nodes=5, backfill_time_min=60),
+                BackfillWindow(num_nodes=15, backfill_time_min=45),
             ],
-            'debug_queue': [
-                BackfillWindow(num_nodes=1,backfill_time_min=60),
-                BackfillWindow(num_nodes=3,backfill_time_min=20)
-            ]
+            "debug_queue": [
+                BackfillWindow(num_nodes=1, backfill_time_min=60),
+                BackfillWindow(num_nodes=3, backfill_time_min=20),
+            ],
         }
         return windows

--- a/balsam/platform/scheduler/dummy.py
+++ b/balsam/platform/scheduler/dummy.py
@@ -1,4 +1,4 @@
-from .scheduler import SubprocessSchedulerInterface
+from .scheduler import SubprocessSchedulerInterface, JobStatus, BackfillWindow
 
 
 def parse_time_minutes(t_str):
@@ -24,7 +24,7 @@ class DummyScheduler(SubprocessSchedulerInterface):
     status_exe = "echo"
     submit_exe = "bash"
     delete_exe = "echo"
-    nodelist_exe = "echo"
+    backfill_exe = "echo"
 
     # maps scheduler states to Balsam states
     # the keys of this dictionary should
@@ -69,7 +69,6 @@ class DummyScheduler(SubprocessSchedulerInterface):
             "time_remaining_min": parse_time_minutes,
             "wall_time_min": parse_time_minutes,
             "state": DummyScheduler._job_state_map,
-            "backfill_time": lambda x: parse_backfill_time(x),
         }
         return status_field_map.get(balsam_field, lambda x: x)
 
@@ -173,21 +172,21 @@ class DummyScheduler(SubprocessSchedulerInterface):
         for line in job_lines:
             job_stat = self._parse_status_line(line)
             if job_stat:
-                id = int(job_stat["id"])
+                id = int(job_stat.id)
                 status_dict[id] = job_stat
         return status_dict
 
     def _parse_status_line(self, line):
-        status = {}
         fields = line.split()
         if len(fields) != len(self.status_fields):
-            return status
+            return JobStatus()
 
+        status = {}
         for name, value in zip(self.status_fields, fields):
             func = DummyScheduler._status_field_map(name)
             status[name] = func(value)
 
-        return status
+        return JobStatus(**status)
 
     def _render_delete_args(self, job_id):
         args = [
@@ -197,32 +196,25 @@ class DummyScheduler(SubprocessSchedulerInterface):
 
         return args
 
-    def _render_nodelist_args(self):
+    def _render_backfill_args(self):
         args = [
-            self.nodelist_exe,
+            self.backfill_exe,
             self._nodelist_output,
         ]
         return args
 
-    def _parse_nodelist_output(self, stdout):
-        raw_lines = stdout.split("\n")
-        nodelist = {}
-        node_lines = raw_lines[2:]
-        for line in node_lines:
-            node_stat = self._parse_nodelist_line(line)
-            if node_stat:
-                id = str(node_stat["id"])
-                nodelist[id] = node_stat
-        return nodelist
+    def _parse_backfill_output(self, stdout):
+        # parse stdout here
 
-    def _parse_nodelist_line(self, line):
-        status = {}
-        fields = line.split()
-        if len(fields) != len(self.nodelist_fields):
-            return status
-
-        for name, value in zip(self.nodelist_fields, fields):
-            func = DummyScheduler._nodelist_field_map(name)
-            status[name] = func(value)
-
-        return status
+        # build example output dictionary
+        windows = {
+            'default_queue': [
+                BackfillWindow(num_nodes=5,backfill_time_min=60),
+                BackfillWindow(num_nodes=15,backfill_time_min=45)
+            ],
+            'debug_queue': [
+                BackfillWindow(num_nodes=1,backfill_time_min=60),
+                BackfillWindow(num_nodes=3,backfill_time_min=20)
+            ]
+        }
+        return windows

--- a/balsam/platform/scheduler/scheduler.py
+++ b/balsam/platform/scheduler/scheduler.py
@@ -1,10 +1,25 @@
 from getpass import getuser
 import subprocess
 import os
+import collections
 
 
 class SchedulerNonZeroReturnCode(Exception):
     pass
+
+
+""" JobStatus contains the status of a pending or running job """
+JobStatus = collections.namedtuple(
+    "JobStatus",
+    ["id", "state", "queue", "nodes", "wall_time_min", "project", "time_remaining_min"],
+    defaults=[None, None, None, None, None, None, None],
+)
+
+
+""" BackfillWindow contains a number of nodes which are free for some available time """
+BackfillWindow = collections.namedtuple(
+    "BackfillWindow", ["num_nodes", "backfill_time_min"], defaults=[None, None]
+)
 
 
 def scheduler_subproc(args, cwd=None):
@@ -43,7 +58,8 @@ class SchedulerInterface(object):
 
     def get_statuses(self, project=None, user=None, queue=None):
         """
-        Returns list of JobStatus for each job belonging to current user
+        Returns dictionary keyed on scheduler job id and a value of JobStatus for each
+          job belonging to current user, project, and/or queue
         """
         raise NotImplementedError
 
@@ -53,9 +69,10 @@ class SchedulerInterface(object):
         """
         raise NotImplementedError
 
-    def get_site_nodelist(self):
+    def get_backfill_windows(self):
         """
-        Returns a list of NodeWindows on the system
+        Returns a dictionary keyed on queue name and a value of list of
+          BackfillWindow on the system for available scheduling windows
         """
         raise NotImplementedError
 
@@ -64,7 +81,6 @@ class SubprocessSchedulerInterface(SchedulerInterface):
     def submit(
         self, script_path, project, queue, num_nodes, time_minutes, cwd=None, **kwargs
     ):
-
         submit_args = self._render_submit_args(
             script_path, project, queue, num_nodes, time_minutes, **kwargs
         )
@@ -83,11 +99,8 @@ class SubprocessSchedulerInterface(SchedulerInterface):
         stdout = scheduler_subproc(delete_args)
         return stdout
 
-    def get_site_nodelist(self):
-        """
-        Get available compute nodes system-wide
-        """
-        nodelist_args = self._render_nodelist_args()
-        stdout = scheduler_subproc(nodelist_args)
-        nodelist = self._parse_nodelist_output(stdout)
-        return nodelist
+    def get_backfill_windows(self):
+        backfill_args = self._render_backfill_args()
+        stdout = scheduler_subproc(backfill_args)
+        backfill_windows = self._parse_backfill_output(stdout)
+        return backfill_windows

--- a/balsam/platform/scheduler/slurm_sched.py
+++ b/balsam/platform/scheduler/slurm_sched.py
@@ -1,4 +1,4 @@
-from .scheduler import SubprocessSchedulerInterface, JobStatus, BackfillWindow
+from .scheduler import SubprocessSchedulerInterface, JobStatus
 import os
 import logging
 
@@ -248,44 +248,44 @@ class SlurmScheduler(SubprocessSchedulerInterface):
         # TODO: to extract backfill information
         return {}
 
-        raw_lines = stdout.split("\n")
-        windows = {}
-        sinfo_lines = raw_lines[1:]
-        for line in sinfo_lines:
-            self._parse_sinfo_line(line, nodelist)
-        return nodelist
+        # raw_lines = stdout.split("\n")
+        # windows = {}
+        # sinfo_lines = raw_lines[1:]
+        # for line in sinfo_lines:
+        #     self._parse_sinfo_line(line, nodelist)
+        # return nodelist
 
-    def _parse_sinfo_line(self, line, nodelist):
-        fields = line.split()
-        if len(fields) != len(self.nodelist_fields):
-            return
-
-        node_ids = self._parse_node_field(fields[0])
-        num_nodes = len(node_ids)
-
-        queue = fields[1]
-        status = self._node_state_map(fields[2])
-
-        for node_id in node_ids:
-            if node_id in nodelist:
-                nodelist[node_id]["queues"].append(queue)
-                nodelist[node_id]["state"] = status
-            else:
-                nodelist[node_id] = {"queues": [queue], "state": status}
-
-    @staticmethod
-    def _parse_node_field(nodes_str):
-        node_numbers_str = nodes_str[len("nid[") : -1]
-        node_ranges = node_numbers_str.split(",")
-        node_ids = []
-        for node_range in node_ranges:
-            if "-" in node_range:
-                parts = node_range.split("-")
-                min = int(parts[0])
-                max = int(parts[1])
-                for i in range(min, max + 1):
-                    node_ids.append(i)
-            else:
-                node_ids.append(int(node_range))
-
-        return node_ids
+    # def _parse_sinfo_line(self, line, nodelist):
+    #     fields = line.split()
+    #     if len(fields) != len(self.nodelist_fields):
+    #         return
+    #
+    #     node_ids = self._parse_node_field(fields[0])
+    #     num_nodes = len(node_ids)
+    #
+    #     queue = fields[1]
+    #     status = self._node_state_map(fields[2])
+    #
+    #     for node_id in node_ids:
+    #         if node_id in nodelist:
+    #             nodelist[node_id]["queues"].append(queue)
+    #             nodelist[node_id]["state"] = status
+    #         else:
+    #             nodelist[node_id] = {"queues": [queue], "state": status}
+    #
+    # @staticmethod
+    # def _parse_node_field(nodes_str):
+    #     node_numbers_str = nodes_str[len("nid[") : -1]
+    #     node_ranges = node_numbers_str.split(",")
+    #     node_ids = []
+    #     for node_range in node_ranges:
+    #         if "-" in node_range:
+    #             parts = node_range.split("-")
+    #             min = int(parts[0])
+    #             max = int(parts[1])
+    #             for i in range(min, max + 1):
+    #                 node_ids.append(i)
+    #         else:
+    #             node_ids.append(int(node_range))
+    #
+    #     return node_ids

--- a/balsam/platform/scheduler/slurm_sched.py
+++ b/balsam/platform/scheduler/slurm_sched.py
@@ -38,7 +38,7 @@ class SlurmScheduler(SubprocessSchedulerInterface):
     status_exe = "squeue"
     submit_exe = "sbatch"
     delete_exe = "scancel"
-    nodelist_exe = "sinfo"
+    backfill_exe = "sinfo"
     default_submit_kwargs = {}
     submit_kwargs_flag_map = {}
 
@@ -212,10 +212,10 @@ class SlurmScheduler(SubprocessSchedulerInterface):
     def _render_delete_args(self, job_id):
         return [self.delete_exe, str(job_id)]
 
-    def _render_nodelist_args(self):
-        return [self.nodelist_exe]
+    def _render_backfill_args(self):
+        return [self.backfill_exe]
 
-    def _parse_submit_output(self, submit_output):
+    def _parse_backfill_output(self, submit_output):
         try:
             scheduler_id = int(submit_output)
         except ValueError:

--- a/balsam/platform/tests/test_scheduler.py
+++ b/balsam/platform/tests/test_scheduler.py
@@ -85,7 +85,6 @@ class SchedulerTestMixin(object):
         self.assertGreaterEqual(len(windows), 0)
 
         # verify that nodelist has expected output
-        node_states = self.scheduler.node_states.values()
         for queue, windows in windows.items():
             for window in windows:
                 self.assertIsInstance(window.num_nodes, int)

--- a/balsam/platform/tests/test_scheduler.py
+++ b/balsam/platform/tests/test_scheduler.py
@@ -11,7 +11,7 @@ from balsam.platform.scheduler.dummy import DummyScheduler
 class SchedulerTestMixin(object):
     def assertInPath(self, exe):
         which_exe = shutil.which(exe)
-        self.assertTrue(which_exe is not None)
+        self.assertTrue(which_exe is not None, f"'{exe}' not in PATH")
 
     def test_submit(self):
 
@@ -53,14 +53,14 @@ class SchedulerTestMixin(object):
         # check that all states are expected
         balsam_job_states = self.scheduler.job_states.values()
         for id, job_status in stat_dict.items():
-            self.assertIsInstance(job_status["project"], str)
-            self.assertIsInstance(job_status["queue"], str)
-            self.assertIsInstance(job_status["nodes"], int)
-            self.assertIsInstance(job_status["wall_time_min"], int)
+            self.assertIsInstance(job_status.project, str)
+            self.assertIsInstance(job_status.queue, str)
+            self.assertIsInstance(job_status.nodes, int)
+            self.assertIsInstance(job_status.wall_time_min, int)
 
-            self.assertIn(job_status["state"], balsam_job_states)
-            self.assertGreaterEqual(job_status["wall_time_min"], 0)
-            self.assertGreater(job_status["nodes"], 0)
+            self.assertIn(job_status.state, balsam_job_states)
+            self.assertGreaterEqual(job_status.wall_time_min, 0)
+            self.assertGreater(job_status.nodes, 0)
 
         # clean up after this test, delete job, wait for delete to be complete
         self.scheduler.delete_job(job_id)
@@ -76,20 +76,20 @@ class SchedulerTestMixin(object):
         # validate output
         self.assertIsInstance(stdout, str)
 
-    def test_get_site_nodelist(self):
+    def test_get_backfill_windows(self):
         # verify nodelist command is in path
-        self.assertInPath(self.scheduler.nodelist_exe)
+        self.assertInPath(self.scheduler.backfill_exe)
 
-        nodelist = self.scheduler.get_site_nodelist()
-        self.assertIsInstance(nodelist, dict)
-        self.assertGreater(len(nodelist), 0)
+        windows = self.scheduler.get_backfill_windows()
+        self.assertIsInstance(windows, dict)
+        self.assertGreaterEqual(len(windows), 0)
 
         # verify that nodelist has expected output
         node_states = self.scheduler.node_states.values()
-        for id, node_status in nodelist.items():
-            self.assertIsInstance(node_status["state"], str)
-            self.assertIsInstance(node_status["queues"], list)
-            self.assertIn(node_status["state"], node_states)
+        for queue, windows in windows.items():
+            for window in windows:
+                self.assertIsInstance(window.num_nodes, int)
+                self.assertIsInstance(window.backfill_time_min, int)
 
 
 class DummyTest(SchedulerTestMixin, unittest.TestCase):


### PR DESCRIPTION
Updated scheduler interface to use namedtuples which provides a bit more rigid data model for inherited scheduler classes. Also helps solidify the tests performed. In this change, I also updated the Dummy, Slurm, and Cobalt schedulers to conform to this new data model. Currently the SLURM backfill method is empty and will need to be implemented when we understand from Slurm experts how to best extract backfill windows from the scheduler.