### PR TITLE
add setproctitle to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,6 +38,7 @@ install_requires =
     sphinx_rtd_theme
     numpy
     psutil
+    setproctitle
 python_requires = >=3.6
 scripts =
     balsam/scripts/balsamactivate


### PR DESCRIPTION
Balsam appears to be missing a dependency on the Python package `setproctitle`, so I have added this to `setup.cfg`.